### PR TITLE
Opening Realm and creating object before benchmark

### DIFF
--- a/app/src/storages/Realm.ts
+++ b/app/src/storages/Realm.ts
@@ -9,27 +9,19 @@ const TestSchema = {
   primaryKey: '_id',
 };
 
-const realm = (async () => {
-  const r = await Realm.open({
-    path: 'myrealm',
-    schema: [TestSchema],
-  });
-  r.write(() => {
-    r.deleteAll();
-    r.create('Test', {
-      _id: 1,
-      value: 'hello',
-    });
-  });
-  return r;
-})();
+const realm = new Realm({
+  schema: [TestSchema],
+});
 
-export async function getFromRealm(): Promise<string> {
-  const r = await realm;
-  const object = r.objectForPrimaryKey('Test', 1);
-  if (object == null || typeof object.value !== 'string') {
-    throw new Error('RealmDB: Object not found!');
-  }
+realm.write(() => {
+  realm.deleteAll();
+  realm.create('Test', {
+    _id: 1,
+    value: 'hello',
+  });
+});
 
+export function getFromRealm() {
+  const object = realm.objectForPrimaryKey('Test', 1);
   return object.value;
 }


### PR DESCRIPTION
There's no real need for `getFromRealm` to be async and to make this comparable to the MMKV code, I think it more fair to open the database and create the object before running the benchmark:

https://github.com/mrousavy/StorageBenchmark/blob/2bb8357f5fd38d842ac55aa36443d48af8652a46/app/src/storages/MMKV.ts#L5-L8

These are the results I'm getting on my M1 in an iOS simulator.

```
 LOG  Running Benchmark in 3... 2... 1...
 LOG  Starting Benchmark "MMKV                 "...
 LOG  Finished Benchmark "MMKV                 "! Took 7.8389ms!
 LOG  Starting Benchmark "MMKV Encrypt         "...
 LOG  Finished Benchmark "MMKV Encrypt         "! Took 8.3548ms!
 LOG  Starting Benchmark "AsyncStorage         "...
 LOG  Finished Benchmark "AsyncStorage         "! Took 160.5971ms!
 LOG  Starting Benchmark "Expo Secure Storage  "...
 LOG  Finished Benchmark "Expo Secure Storage  "! Took 437.3063ms!
 LOG  Starting Benchmark "React Native Keychain"...
 LOG  Finished Benchmark "React Native Keychain"! Took 444.2637ms!
 LOG  Starting Benchmark "SQLite               "...
 LOG  Finished Benchmark "SQLite               "! Took 48.8826ms!
 LOG  Starting Benchmark "RealmDB              "...
 LOG  Finished Benchmark "RealmDB              "! Took 22.7460ms!
 LOG  Starting Benchmark "WatermelonDB         "...
 LOG  Finished Benchmark "WatermelonDB         "! Took 48.0482ms!
```
