### PR TITLE
Moving object read out of the `realm` test

### DIFF
--- a/app/src/storages/Realm.ts
+++ b/app/src/storages/Realm.ts
@@ -21,7 +21,8 @@ realm.write(() => {
   });
 });
 
+const object = realm.objectForPrimaryKey('Test', 1);
+
 export function getFromRealm() {
-  const object = realm.objectForPrimaryKey('Test', 1);
   return object.value;
 }


### PR DESCRIPTION
Depending on the interpretation of [the "operations" section of the readme](https://github.com/mrousavy/StorageBenchmark?tab=readme-ov-file#operations):

> The above results were tested using get operations for a single string key (value: 'hello'). Results may differ when using other operations, such as set, delete, update, and more.

One could argue that getting the object shouldn't be a part of the workload being benchmarked, but instead simply getting the string value from the object. In Realm, no object values are pre-fetched and the app does indeed hit the database when doing a property get on the accessor object, such as the get of `value` from the `object` in the code referenced by this PR.

These are the results I'm getting on my M1 in an iOS simulator.

```
Running Benchmark in 3... 2... 1...
 LOG  Starting Benchmark "MMKV                 "...
 LOG  Finished Benchmark "MMKV                 "! Took 10.7082ms!
 LOG  Starting Benchmark "MMKV Encrypt         "...
 LOG  Finished Benchmark "MMKV Encrypt         "! Took 8.9380ms!
 LOG  Starting Benchmark "AsyncStorage         "...
 LOG  Finished Benchmark "AsyncStorage         "! Took 159.2168ms!
 LOG  Starting Benchmark "Expo Secure Storage  "...
 LOG  Finished Benchmark "Expo Secure Storage  "! Took 452.1540ms!
 LOG  Starting Benchmark "React Native Keychain"...
 LOG  Finished Benchmark "React Native Keychain"! Took 443.7793ms!
 LOG  Starting Benchmark "SQLite               "...
 LOG  Finished Benchmark "SQLite               "! Took 65.9985ms!
 LOG  Starting Benchmark "RealmDB              "...
 LOG  Finished Benchmark "RealmDB              "! Took 10.1010ms!
 LOG  Starting Benchmark "WatermelonDB         "...
 LOG  Finished Benchmark "WatermelonDB         "! Took 62.3027ms!
 ```