### PR TITLE
Reading Realm values from a `Realm.Dictionary`

### DIFF
--- a/app/src/storages/Realm.ts
+++ b/app/src/storages/Realm.ts
@@ -3,25 +3,26 @@ import Realm from 'realm';
 const TestSchema = {
   name: 'Test',
   properties: {
-    _id: 'int',
-    value: 'string',
+    dict: '{}',
   },
-  primaryKey: '_id',
+};
+
+type Test = {
+  dict: Realm.Dictionary;
 };
 
 const realm = new Realm({
   schema: [TestSchema],
+  deleteRealmIfMigrationNeeded: true,
 });
 
-realm.write(() => {
+const object = realm.write(() => {
   realm.deleteAll();
-  realm.create('Test', {
-    _id: 1,
-    value: 'hello',
-  });
+  return realm.create<Test>('Test', {dict: {k: 'hello'}});
 });
+
+const dict = object.dict;
 
 export function getFromRealm() {
-  const object = realm.objectForPrimaryKey('Test', 1);
-  return object.value;
+  return dict.k;
 }


### PR DESCRIPTION
I believe this closer resembles the access pattern used by the MMKV test function, as this will access values from a dictionary of arbitrary key/value pairs. There is no pre-fetching or caching of the values in the Realm SDK layer and the database is hit on every get as with MMKV (there are of course some at the lower levels, as with any database).

These are the results I'm getting on my M1 in an iOS simulator.

```
 LOG  Running Benchmark in 3... 2... 1...
 LOG  Starting Benchmark "MMKV                 "...
 LOG  Finished Benchmark "MMKV                 "! Took 10.8298ms!
 LOG  Starting Benchmark "MMKV Encrypt         "...
 LOG  Finished Benchmark "MMKV Encrypt         "! Took 8.3246ms!
 LOG  Starting Benchmark "AsyncStorage         "...
 LOG  Finished Benchmark "AsyncStorage         "! Took 188.2416ms!
 LOG  Starting Benchmark "Expo Secure Storage  "...
 LOG  Finished Benchmark "Expo Secure Storage  "! Took 980.0811ms!
 LOG  Starting Benchmark "React Native Keychain"...
 LOG  Finished Benchmark "React Native Keychain"! Took 566.4805ms!
 LOG  Starting Benchmark "SQLite               "...
 LOG  Finished Benchmark "SQLite               "! Took 45.7815ms!
 LOG  Starting Benchmark "RealmDB              "...
 LOG  Finished Benchmark "RealmDB              "! Took 11.4357ms!
 LOG  Starting Benchmark "WatermelonDB         "...
 LOG  Finished Benchmark "WatermelonDB         "! Took 35.5760ms!
 ```